### PR TITLE
Change logic for legacy magic methods

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1436,7 +1436,7 @@ class TestValidationHook(TestCase):
 
             @validate('value')
             def _value_validate(self, proposal):
-                name,value = proposal['name'],proposal['value']
+                name, value = proposal['name'], proposal['value']
                 if self.parity == 'even' and value % 2:
                     raise TraitError('Expected an even number')
                 if self.parity == 'odd' and (value % 2 == 0):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -498,7 +498,6 @@ class TraitType(BaseDescriptor):
             value = cross_validate(value, self)
         return value
 
-
     def __or__(self, other):
         if isinstance(other, Union):
             return Union([self] + other.trait_types)
@@ -949,6 +948,10 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         if name in self._trait_validators:
             raise TraitError("A cross-validator for the trait"
                              " '%s' already exists" % name)
+        if hasattr(self, '_%s_validate' % name):
+            warn("_[traitname]_validate handlers are deprecated. use register_validator instead",
+                 DeprecationWarning, stacklevel=2)
+
         self._trait_validators[name] = handler
 
     @classmethod

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -488,21 +488,14 @@ class TraitType(BaseDescriptor):
         return value
 
     def _cross_validate(self, obj, value):
-        try:
-            cb = getattr(obj, '_%s_validate' % self.name)
-            if cb in obj._trait_validators.get(self.name,[]):
-                raise
-        except:
-            if self.name in obj._trait_validators:
-                proposal = {'name':self.name, 'value':value, 'owner':obj}
-                value = obj._trait_validators[self.name](proposal)
-        else:
+        if self.name in obj._trait_validators:
+            proposal = {'name': self.name, 'value': value, 'owner': obj}
+            value = obj._trait_validators[self.name](proposal)
+        elif hasattr(obj, '_%s_validate' % self.name):
             warn("_[traitname]_validate handlers are deprecated: use register_validator instead",
                  DeprecationWarning, stacklevel=2)
-            if self.name in obj._trait_validators:
-                raise TraitError('Only one cross-validator is allowed: two were found')
-            value = cb(value, self)
-            
+            cross_validate = getattr(obj, '_%s_validate' % self.name)
+            value = cross_validate(value, self)
         return value
 
 
@@ -685,7 +678,7 @@ class ObserveHandler(EventHandler):
 
     def __init__(self, names=None):
         if names is None:
-            self.names=[None]
+            self.names = [None]
         else:
             self.names = names
 
@@ -809,16 +802,13 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         callables.extend(self._trait_notifiers.get('anytrait', []))
 
         # Now static ones
-        try:
-            cb = getattr(self, '_%s_changed' % name)
-            if cb in self._trait_notifiers.get(name,[]):
-                raise
-        except:
-            pass
-        else:
+        if hasattr(self, '_%s_changed' % name):
             warn("_[traitname]_changed change handlers are deprecated: use observe and unobserve instead", 
                  DeprecationWarning, stacklevel=2)
-            callables.append(_callback_wrapper(cb))
+            cb = getattr(self, '_%s_changed' % name)
+            # Only append the magic method if it was not manually registered
+            if cb not in callables:
+                callables.append(_callback_wrapper(cb))
 
         # Call them all now
         # Traits catches and logs errors here.  I allow them to raise


### PR DESCRIPTION
@rmorshea opening a PR to your PR simplifying a bit the logic on checking both the registered handlers and magic methods.
